### PR TITLE
Improve error handling and logging in services

### DIFF
--- a/service1/service1.py
+++ b/service1/service1.py
@@ -1,12 +1,32 @@
 from flask import Flask, request, jsonify
-import subprocess, json, traceback
+import subprocess
+import json
+import logging
 
 app = Flask(__name__)
 
-def run(cmd):
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def run(cmd: str) -> str:
+    """Run shell command and return stdout or raise error with details."""
+    logger.info("Running command: %s", cmd)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     if proc.returncode != 0:
-        raise Exception(f"Command `{cmd}` failed:\n{proc.stderr.strip()}")
+        logger.error(
+            "Command failed with exit code %s: %s\nstdout:\n%s\nstderr:\n%s",
+            proc.returncode,
+            cmd,
+            proc.stdout,
+            proc.stderr,
+        )
+        raise RuntimeError(
+            f"Command `{cmd}` failed with exit code {proc.returncode}. "
+            f"{proc.stderr.strip()}"
+        )
+    logger.info("Command succeeded: %s", cmd)
     return proc.stdout
 
 @app.route('/download-transcribe', methods=['POST'])
@@ -31,7 +51,7 @@ def download_transcribe():
             'inputPath':  'input.mp4'
         })
     except Exception as e:
-        traceback.print_exc()
+        logger.exception("Internal error")
         return jsonify(error=str(e)), 500
 
 if __name__ == '__main__':

--- a/service3/service3.py
+++ b/service3/service3.py
@@ -1,12 +1,31 @@
 from flask import Flask, request, jsonify
-import subprocess, traceback
+import subprocess
+import logging
 
 app = Flask(__name__)
 
-def run(cmd):
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def run(cmd: str) -> str:
+    """Run shell command and return stdout or raise error with details."""
+    logger.info("Running command: %s", cmd)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     if proc.returncode != 0:
-        raise Exception(f"Command `{cmd}` failed:\n{proc.stderr.strip()}")
+        logger.error(
+            "Command failed with exit code %s: %s\nstdout:\n%s\nstderr:\n%s",
+            proc.returncode,
+            cmd,
+            proc.stdout,
+            proc.stderr,
+        )
+        raise RuntimeError(
+            f"Command `{cmd}` failed with exit code {proc.returncode}. "
+            f"{proc.stderr.strip()}"
+        )
+    logger.info("Command succeeded: %s", cmd)
     return proc.stdout
 
 @app.route('/edit', methods=['POST'])
@@ -20,7 +39,7 @@ def edit_video():
         run(f'ffmpeg -y -i "{input_path}" -vf scale=720:-1 "{output_path}"')
         return jsonify({'editedPath': output_path})
     except Exception as e:
-        traceback.print_exc()
+        logger.exception("Internal error")
         return jsonify(error=str(e)), 500
 
 if __name__ == '__main__':

--- a/service4/service4.py
+++ b/service4/service4.py
@@ -1,7 +1,11 @@
 from flask import Flask, request, jsonify
-import traceback
+import logging
 
 app = Flask(__name__)
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
 
 @app.route('/publish-short', methods=['POST'])
 def publish_short():
@@ -15,7 +19,7 @@ def publish_short():
         # Here would be the real upload logic
         return jsonify({'status': 'ok', 'platform': platform, 'accounts': accounts})
     except Exception as e:
-        traceback.print_exc()
+        logger.exception("Internal error")
         return jsonify(error=str(e)), 500
 
 if __name__ == '__main__':

--- a/service5/service5.py
+++ b/service5/service5.py
@@ -1,7 +1,11 @@
 from flask import Flask, request, jsonify
-import traceback
+import logging
 
 app = Flask(__name__)
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
 
 @app.route('/publish-long', methods=['POST'])
 def publish_long():
@@ -13,7 +17,7 @@ def publish_long():
             return jsonify(error='Missing videoPath or accounts'), 400
         return jsonify({'status': 'ok', 'accounts': accounts})
     except Exception as e:
-        traceback.print_exc()
+        logger.exception("Internal error")
         return jsonify(error=str(e)), 500
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add logging setup in each service
- wrap subprocess calls to capture exit codes and output
- use logger.exception for internal errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684344e5051c8330a8daa064943c5cdc